### PR TITLE
Add Swagger (OpenAPI) documentation for all APIs (#7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.2.0",
         "@nestjs/typeorm": "^11.0.0",
         "@types/bcryptjs": "^2.4.6",
         "@types/passport-jwt": "^4.0.1",
@@ -30,6 +31,7 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "sqlite3": "^5.1.7",
+        "swagger-ui-express": "^5.0.1",
         "typeorm": "^0.3.25"
       },
       "devDependencies": {
@@ -1942,6 +1944,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.0.4.tgz",
@@ -2713,6 +2721,39 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.0.tgz",
+      "integrity": "sha512-5wolt8GmpNcrQv34tIPUtPoV1EeFbCetm40Ij3+M0FNNnf2RJ3FyWfuQvI8SBlcJyfaounYVTKzKHreFXsUyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.2.0",
+        "swagger-ui-dist": "5.21.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.5",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.5.tgz",
@@ -2892,6 +2933,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -4706,7 +4754,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -8857,7 +8904,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -12094,6 +12140,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
+      "integrity": "sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.2.0",
     "@nestjs/typeorm": "^11.0.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/passport-jwt": "^4.0.1",
@@ -44,6 +45,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "sqlite3": "^5.1.7",
+    "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.25"
   },
   "devDependencies": {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,12 +1,35 @@
-import { Controller, Post, Body, ValidationPipe } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  ValidationPipe,
+  UseGuards,
+  Get,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { CreateUserDto } from '../users/dto/create-user.dto';
+import { JwtAuthGuard } from './jwt-auth.guard';
+import { ReqUser } from './req-user.decorator'; // assuming custom decorator
+import { AuthResponseDto } from './dto/user.dto';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 
+@ApiTags('Authentication')
 @Controller('api/v1/auth')
 export class AuthController {
   constructor(private authService: AuthService) {}
 
   @Post('register')
+  @ApiOperation({ summary: 'Register a new user' })
+  @ApiResponse({
+    status: 201,
+    description: 'User registered successfully',
+    type: AuthResponseDto,
+  })
   async register(@Body(ValidationPipe) createUserDto: CreateUserDto) {
     return this.authService.register(
       createUserDto.username,
@@ -16,13 +39,26 @@ export class AuthController {
   }
 
   @Post('login')
+  @ApiOperation({ summary: 'Authenticate a user and return JWT token' })
+  @ApiResponse({
+    status: 200,
+    description: 'User logged in successfully',
+    type: AuthResponseDto,
+  })
   async login(@Body() req: { username: string; password: string }) {
     return this.authService.login(req.username, req.password);
   }
 
   @UseGuards(JwtAuthGuard)
-@Get('me')
-me(@ReqUser() user: { userId: string; email: string; role: string }) {
-return user; // from JwtStrategy.validate
-}
+  @Get('me')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get the currently logged-in user' })
+  @ApiResponse({
+    status: 200,
+    description: 'Authenticated user details',
+    type: UserDto,
+  })
+  me(@ReqUser() user: { userId: string; email: string; role: string }) {
+    return user; // comes from JwtStrategy.validate
+  }
 }

--- a/src/auth/dto/auth-response.dto.ts
+++ b/src/auth/dto/auth-response.dto.ts
@@ -1,24 +1,45 @@
 import { Expose, plainToInstance } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
 import { User } from '../../users/user.entity';
 
-
 export class UserDto {
-@Expose() id: string;
-@Expose() username: string;
-@Expose() email: string;
-@Expose() bio?: string | null;
-@Expose() role: string;
-@Expose() createdAt: Date;
-@Expose() updatedAt: Date;
+  @ApiProperty({ example: '1a2b3c', description: 'Unique user ID' })
+  @Expose()
+  id: string;
 
+  @ApiProperty({ example: 'john_doe', description: 'Username of the user' })
+  @Expose()
+  username: string;
 
-static from(user: User) {
-return plainToInstance(UserDto, user, { excludeExtraneousValues: true });
+  @ApiProperty({ example: 'john@example.com', description: 'Email address of the user' })
+  @Expose()
+  email: string;
+
+  @ApiProperty({ example: 'Software developer', required: false })
+  @Expose()
+  bio?: string | null;
+
+  @ApiProperty({ example: 'user', description: 'Role assigned to the user' })
+  @Expose()
+  role: string;
+
+  @ApiProperty({ example: '2025-01-01T12:00:00.000Z' })
+  @Expose()
+  createdAt: Date;
+
+  @ApiProperty({ example: '2025-01-10T12:00:00.000Z' })
+  @Expose()
+  updatedAt: Date;
+
+  static from(user: User) {
+    return plainToInstance(UserDto, user, { excludeExtraneousValues: true });
+  }
 }
-}
-
 
 export class AuthResponseDto {
-token: string;
-user: UserDto;
+  @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' })
+  token: string;
+
+  @ApiProperty({ type: () => UserDto })
+  user: UserDto;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,21 +1,34 @@
-import { ValidationPipe } from '@nestjs/common';
+import { ValidationPipe, ClassSerializerInterceptor } from '@nestjs/common';
 import { NestFactory, Reflector } from '@nestjs/core';
-import { ClassSerializerInterceptor } from '@nestjs/common';
 import { AppModule } from './app.module';
-
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
-const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule);
 
+  // Global pipes
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
 
-app.useGlobalPipes(
-new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true })
-);
+  // Global interceptors
+  app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
 
+  // Swagger setup
+  const config = new DocumentBuilder()
+    .setTitle('Backend API')
+    .setDescription('API documentation for our project')
+    .setVersion('1.0')
+    .addBearerAuth() // JWT auth if you use it
+    .build();
 
-app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api/docs', app, document);
 
-
-await app.listen(3000);
+  await app.listen(3000);
 }
 bootstrap();

--- a/src/mesh-nodes/dto/create-mesh-node.dto.ts
+++ b/src/mesh-nodes/dto/create-mesh-node.dto.ts
@@ -1,23 +1,29 @@
 import { IsString, IsNotEmpty, IsArray, IsOptional, IsEnum } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { MeshNodeStatus } from '../entities/mesh-node.entity';
 
 export class CreateMeshNodeDto {
+  @ApiProperty({ example: 'GraphQL Basics', description: 'Title of the mesh node' })
   @IsString()
   @IsNotEmpty()
   title: string;
 
+  @ApiProperty({ example: 'Introduction to GraphQL fundamentals', description: 'Detailed description' })
   @IsString()
   @IsNotEmpty()
   description: string;
 
+  @ApiProperty({ example: 'Backend', description: 'Category this mesh node belongs to' })
   @IsString()
   @IsNotEmpty()
   category: string;
 
+  @ApiPropertyOptional({ type: [String], example: ['nestjs', 'graphql'], description: 'Tags associated with the node' })
   @IsArray()
   @IsOptional()
   tags?: string[];
 
+  @ApiPropertyOptional({ enum: MeshNodeStatus, description: 'Status of the mesh node' })
   @IsEnum(MeshNodeStatus)
   @IsOptional()
   status?: MeshNodeStatus;

--- a/src/mesh-nodes/mesh-nodes.controller.ts
+++ b/src/mesh-nodes/mesh-nodes.controller.ts
@@ -14,23 +14,30 @@ import { MeshNodesService } from './mesh-nodes.service';
 import { CreateMeshNodeDto } from './dto/create-mesh-node.dto';
 import { UpdateMeshNodeDto } from './dto/update-mesh-node.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
+@ApiTags('Mesh Nodes')
+@ApiBearerAuth() // 🔐 shows lock icon in Swagger
 @Controller('api/v1/mesh-nodes')
 @UseGuards(JwtAuthGuard)
 export class MeshNodesController {
   constructor(private readonly meshNodesService: MeshNodesService) {}
 
   @Post()
+  @ApiOperation({ summary: 'Create a new mesh node' })
+  @ApiResponse({ status: 201, description: 'Mesh node created successfully' })
   create(@Body() createMeshNodeDto: CreateMeshNodeDto, @Request() req) {
     return this.meshNodesService.create(createMeshNodeDto, req.user);
   }
 
   @Get()
+  @ApiOperation({ summary: 'Retrieve all mesh nodes with optional filters' })
+  @ApiResponse({ status: 200, description: 'List of mesh nodes returned' })
   findAll(
-    @Query('category') category?: string, 
+    @Query('category') category?: string,
     @Query('userId') userId?: number,
     @Query('tags') tags?: string,
-    @Query('tagsMode') tagsMode?: 'all' | 'any'
+    @Query('tagsMode') tagsMode?: 'all' | 'any',
   ) {
     if (category) {
       return this.meshNodesService.findByCategory(category);
@@ -40,31 +47,41 @@ export class MeshNodesController {
     }
     if (tags) {
       const tagArray = tags.split(',').map(tag => tag.trim());
-      if (tagsMode === 'all') {
-        return this.meshNodesService.findByTags(tagArray);
-      } else {
-        return this.meshNodesService.findByTagsAny(tagArray);
-      }
+      return tagsMode === 'all'
+        ? this.meshNodesService.findByTags(tagArray)
+        : this.meshNodesService.findByTagsAny(tagArray);
     }
     return this.meshNodesService.findAll();
   }
 
   @Post('suggest-tags')
+  @ApiOperation({ summary: 'Suggest tags based on title and description' })
+  @ApiResponse({ status: 200, description: 'Suggested tags returned' })
   suggestTags(@Body() body: { title: string; description: string }) {
     return this.meshNodesService.suggestTagsForMeshNode(body.title, body.description);
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Retrieve a mesh node by ID' })
+  @ApiResponse({ status: 200, description: 'Mesh node details returned' })
   findOne(@Param('id') id: string) {
     return this.meshNodesService.findOne(+id);
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateMeshNodeDto: UpdateMeshNodeDto, @Request() req) {
+  @ApiOperation({ summary: 'Update a mesh node by ID' })
+  @ApiResponse({ status: 200, description: 'Mesh node updated successfully' })
+  update(
+    @Param('id') id: string,
+    @Body() updateMeshNodeDto: UpdateMeshNodeDto,
+    @Request() req,
+  ) {
     return this.meshNodesService.update(+id, updateMeshNodeDto, req.user);
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Delete a mesh node by ID' })
+  @ApiResponse({ status: 200, description: 'Mesh node removed successfully' })
   remove(@Param('id') id: string, @Request() req) {
     return this.meshNodesService.remove(+id, req.user);
   }

--- a/src/solutions/dto/create-solution.dto.ts
+++ b/src/solutions/dto/create-solution.dto.ts
@@ -1,11 +1,14 @@
 import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateSolutionDto {
+  @ApiProperty({ example: 'You can optimize by using indexes in your DB.', description: 'Solution content (min 10 chars)' })
   @IsNotEmpty()
   @IsString()
   @MinLength(10, { message: 'Solution content must be at least 10 characters long' })
   content: string;
 
+  @ApiProperty({ example: 101, description: 'ID of the mesh node this solution belongs to' })
   @IsNotEmpty()
   meshNodeId: number;
 }

--- a/src/solutions/dto/vote-solution.dto.ts
+++ b/src/solutions/dto/vote-solution.dto.ts
@@ -1,6 +1,11 @@
-import { IsIn } from 'class-validator';
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
 
-export class VoteSolutionDto {
-  @IsIn(['upvote', 'downvote'])
-  voteType: 'upvote' | 'downvote';
+export class CreateSolutionDto {
+  @IsNotEmpty()
+  @IsString()
+  @MinLength(10, { message: 'Solution content must be at least 10 characters long' })
+  content: string;
+
+  @IsNotEmpty()
+  meshNodeId: number;
 }

--- a/src/solutions/solutions.controller.ts
+++ b/src/solutions/solutions.controller.ts
@@ -15,33 +15,49 @@ import { CreateSolutionDto } from './dto/create-solution.dto';
 import { UpdateSolutionDto } from './dto/update-solution.dto';
 import { VoteSolutionDto } from './dto/vote-solution.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 
+@ApiTags('solutions')
+@ApiBearerAuth() // adds JWT auth field in Swagger
 @Controller('solutions')
 @UseGuards(JwtAuthGuard)
 export class SolutionsController {
   constructor(private readonly solutionsService: SolutionsService) {}
 
   @Post()
+  @ApiOperation({ summary: 'Create a new solution' })
+  @ApiResponse({ status: 201, description: 'Solution successfully created.' })
   create(@Body() createSolutionDto: CreateSolutionDto, @Request() req) {
     return this.solutionsService.create(createSolutionDto, req.user.userId);
   }
 
   @Get()
+  @ApiOperation({ summary: 'Get all solutions' })
+  @ApiResponse({ status: 200, description: 'Return all solutions.' })
   findAll() {
     return this.solutionsService.findAll();
   }
 
   @Get('mesh-node/:meshNodeId')
+  @ApiOperation({ summary: 'Find solutions by mesh node' })
+  @ApiParam({ name: 'meshNodeId', type: Number })
+  @ApiResponse({ status: 200, description: 'Return solutions for given mesh node.' })
   findByMeshNode(@Param('meshNodeId', ParseIntPipe) meshNodeId: number) {
     return this.solutionsService.findByMeshNode(meshNodeId);
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Find one solution by ID' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({ status: 200, description: 'Return solution details.' })
   findOne(@Param('id', ParseIntPipe) id: number) {
     return this.solutionsService.findOne(id);
   }
 
   @Patch(':id')
+  @ApiOperation({ summary: 'Update a solution' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({ status: 200, description: 'Solution updated successfully.' })
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateSolutionDto: UpdateSolutionDto,
@@ -51,6 +67,9 @@ export class SolutionsController {
   }
 
   @Post(':id/vote')
+  @ApiOperation({ summary: 'Vote for a solution (upvote/downvote)' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({ status: 200, description: 'Vote recorded successfully.' })
   vote(
     @Param('id', ParseIntPipe) id: number,
     @Body() voteSolutionDto: VoteSolutionDto,
@@ -59,6 +78,9 @@ export class SolutionsController {
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Delete a solution (soft delete)' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({ status: 200, description: 'Solution deleted successfully.' })
   remove(@Param('id', ParseIntPipe) id: number, @Request() req) {
     return this.solutionsService.remove(id, req.user.userId);
   }

--- a/src/tags/dto/create-tag.dto.ts
+++ b/src/tags/dto/create-tag.dto.ts
@@ -1,18 +1,23 @@
 import { IsNotEmpty, IsString, IsOptional, IsArray } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateTagDto {
+  @ApiProperty({ example: 'nestjs', description: 'Tag name' })
   @IsNotEmpty()
   @IsString()
   name: string;
 
+  @ApiPropertyOptional({ example: 'NestJS framework related tag', description: 'Tag description' })
   @IsOptional()
   @IsString()
   description?: string;
 
+  @ApiPropertyOptional({ example: 'backend', description: 'Category for grouping tags' })
   @IsOptional()
   @IsString()
   category?: string;
 
+  @ApiPropertyOptional({ example: ['nodejs', 'typescript'], description: 'Alternative names' })
   @IsOptional()
   @IsArray()
   @IsString({ each: true })

--- a/src/tags/dto/suggest-tags.dto.ts
+++ b/src/tags/dto/suggest-tags.dto.ts
@@ -1,10 +1,13 @@
 import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class SuggestTagsDto {
+  @ApiProperty({ example: 'Implement caching', description: 'Title of the suggestion' })
   @IsNotEmpty()
   @IsString()
   title: string;
 
+  @ApiProperty({ example: 'We need to add caching to improve performance.', description: 'Detailed description' })
   @IsNotEmpty()
   @IsString()
   description: string;

--- a/src/tags/dto/update-tag.dto.ts
+++ b/src/tags/dto/update-tag.dto.ts
@@ -1,4 +1,8 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreateTagDto } from './create-tag.dto';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
-export class UpdateTagDto extends PartialType(CreateTagDto) {}
+export class UpdateTagDto extends PartialType(CreateTagDto) {
+  @ApiPropertyOptional({ example: 'nestjs-updated', description: 'Updated tag name' })
+  name?: string;
+}

--- a/src/tags/tags.controller.ts
+++ b/src/tags/tags.controller.ts
@@ -15,69 +15,105 @@ import { CreateTagDto } from './dto/create-tag.dto';
 import { UpdateTagDto } from './dto/update-tag.dto';
 import { SuggestTagsDto } from './dto/suggest-tags.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+  ApiParam,
+} from '@nestjs/swagger';
 
+@ApiTags('tags') // Groups all endpoints in Swagger
 @Controller('tags')
 export class TagsController {
   constructor(private readonly tagsService: TagsService) {}
 
   @Post()
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a new tag' })
+  @ApiResponse({ status: 201, description: 'Tag created successfully.' })
+  @ApiResponse({ status: 400, description: 'Invalid input data.' })
   create(@Body() createTagDto: CreateTagDto) {
     return this.tagsService.create(createTagDto);
   }
 
   @Get()
+  @ApiOperation({ summary: 'Get all tags' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Limit number of results' })
+  @ApiResponse({ status: 200, description: 'List of tags.' })
   findAll(@Query('limit') limit?: string) {
     const limitNum = limit ? parseInt(limit, 10) : undefined;
     return this.tagsService.findAll(limitNum);
   }
 
   @Get('popular')
+  @ApiOperation({ summary: 'Get popular tags' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Limit number of results (default 20)' })
+  @ApiResponse({ status: 200, description: 'List of popular tags.' })
   findPopular(@Query('limit') limit?: string) {
     const limitNum = limit ? parseInt(limit, 10) : 20;
     return this.tagsService.findPopular(limitNum);
   }
 
   @Get('search')
-  search(
-    @Query('q') query: string,
-    @Query('limit') limit?: string,
-  ) {
+  @ApiOperation({ summary: 'Search tags by keyword' })
+  @ApiQuery({ name: 'q', required: true, type: String, description: 'Search keyword' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Limit number of results (default 10)' })
+  @ApiResponse({ status: 200, description: 'List of matching tags.' })
+  search(@Query('q') query: string, @Query('limit') limit?: string) {
     const limitNum = limit ? parseInt(limit, 10) : 10;
     return this.tagsService.search(query, limitNum);
   }
 
   @Get('category/:category')
+  @ApiOperation({ summary: 'Find tags by category' })
+  @ApiParam({ name: 'category', type: String })
+  @ApiResponse({ status: 200, description: 'List of tags in the category.' })
   findByCategory(@Param('category') category: string) {
     return this.tagsService.findByCategory(category);
   }
 
   @Get('stats')
+  @ApiOperation({ summary: 'Get tag statistics' })
+  @ApiResponse({ status: 200, description: 'Statistics about tags.' })
   getStats() {
     return this.tagsService.getTagStats();
   }
 
   @Post('suggest')
+  @ApiOperation({ summary: 'Suggest tags based on content' })
+  @ApiResponse({ status: 201, description: 'Tag suggestions returned successfully.' })
   suggestTags(@Body() suggestTagsDto: SuggestTagsDto) {
     return this.tagsService.suggestTags(suggestTagsDto);
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Find one tag by ID' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({ status: 200, description: 'Return tag details.' })
+  @ApiResponse({ status: 404, description: 'Tag not found.' })
   findOne(@Param('id', ParseIntPipe) id: number) {
     return this.tagsService.findOne(id);
   }
 
   @Patch(':id')
   @UseGuards(JwtAuthGuard)
-  update(
-    @Param('id', ParseIntPipe) id: number,
-    @Body() updateTagDto: UpdateTagDto,
-  ) {
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a tag' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({ status: 200, description: 'Tag updated successfully.' })
+  update(@Param('id', ParseIntPipe) id: number, @Body() updateTagDto: UpdateTagDto) {
     return this.tagsService.update(id, updateTagDto);
   }
 
   @Delete(':id')
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a tag' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({ status: 200, description: 'Tag deleted successfully.' })
   remove(@Param('id', ParseIntPipe) id: number) {
     return this.tagsService.remove(id);
   }

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,25 +1,26 @@
 import { IsEmail, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
-
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateUserDto {
-@IsString()
-@MinLength(3)
-@MaxLength(50)
-username: string;
+  @ApiProperty({ example: 'muhammad', description: 'Unique username (3–50 characters)' })
+  @IsString()
+  @MinLength(3)
+  @MaxLength(50)
+  username: string;
 
+  @ApiProperty({ example: 'mdauwal@example.com', description: 'Valid email address' })
+  @IsEmail()
+  email: string;
 
-@IsEmail()
-email: string;
+  @ApiProperty({ example: 'strongPass123', description: 'Password (8–72 characters)' })
+  @IsString()
+  @MinLength(8)
+  @MaxLength(72)
+  password: string;
 
-
-@IsString()
-@MinLength(8)
-@MaxLength(72)
-password: string;
-
-
-@IsOptional()
-@IsString()
-@MaxLength(500)
-bio?: string;
+  @ApiPropertyOptional({ example: 'I love coding and Data', description: 'User bio (optional)' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  bio?: string;
 }


### PR DESCRIPTION
## Summary  
This PR introduces **Swagger (OpenAPI)** documentation for all API endpoints, improving developer experience and enabling easier testing and integration.

## Changes  
- Installed and configured **SwaggerModule** in `main.ts`.  
- Defined API metadata (title, description, version).  
- Exposed API documentation at **`/api/docs`**.  
- Applied **global validation pipes** for strict DTO validation.  
- Enabled **class serializer interceptor** for cleaner API responses.  

## How to Test  
1. Run the project:  
   ```bash
   yarn start:dev
